### PR TITLE
Log  provider exception message

### DIFF
--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -65,8 +65,8 @@ class AuthManager(object):
                 if auth_results[0] is True:
                     try:
                         auth_return = parse_auth_results(trans, auth_results, options)
-                    except Conflict:
-                        log.exception(Conflict)
+                    except Conflict as conflict :
+                        log.exception(conflict)
                         raise
                     return auth_return
                 elif auth_results[0] is None:


### PR DESCRIPTION
Replace the exception class name  by  the instance inner message in the logs.